### PR TITLE
[lint] Add Verilator UNOPTFLAT lint waivers

### DIFF
--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -1050,11 +1050,13 @@ module ibex_id_stage import cheri_pkg::*; #(
                                   ~stall_ld_hz       &
                                   ~stall_cheri_trvk;
 
+    /* verilator lint_off UNOPTFLAT */
     assign instr_executing = instr_valid_i              &
                              ~instr_kill                &
                              ~stall_ld_hz               &
                              ~stall_cheri_trvk          &
                              ~outstanding_memory_access;
+    /* verilator lint_on UNOPTFLAT */
 
     // allowing a cheri instruction to start execution - valid instruction not stalled by WB/hz
     // note we can't use_instr_kill here since it includes id_exception (cherr_ex_err), which causes a

--- a/vendor/lowrisc_ip/ip/prim/lint/prim_arbiter.vlt
+++ b/vendor/lowrisc_ip/ip/prim/lint/prim_arbiter.vlt
@@ -39,6 +39,8 @@ lint_off -rule ALWCOMBORDER -file "*/rtl/prim_arbiter_tree.sv" -match "*data_tre
 
 lint_off -rule ALWCOMBORDER -file "*/rtl/prim_arbiter_ppc.sv" -match "*ppc_out*"
 
+lint_off -rule UNOPTFLAT -file "*/rtl/prim_arbiter_ppc.sv" -match "*winner*"
+
 // Waive unused clk and reset signals: they're just used for
 // assertions (which Verilator doesn't see)
 lint_off -rule UNUSED -file "*/rtl/prim_arbiter_fixed.sv" -match "*clk_i*"

--- a/vendor/patches/lowrisc_ip/ip_prim/0002_add_arbiter_ppc_unoptflat_waiver.patch
+++ b/vendor/patches/lowrisc_ip/ip_prim/0002_add_arbiter_ppc_unoptflat_waiver.patch
@@ -1,0 +1,13 @@
+diff --git a/lint/prim_arbiter.vlt b/lint/prim_arbiter.vlt
+index 42e44b2b..a3d79d90 100644
+--- a/lint/prim_arbiter.vlt
++++ b/lint/prim_arbiter.vlt
+@@ -39,6 +39,8 @@ lint_off -rule ALWCOMBORDER -file "*/rtl/prim_arbiter_tree.sv" -match "*data_tre
+ 
+ lint_off -rule ALWCOMBORDER -file "*/rtl/prim_arbiter_ppc.sv" -match "*ppc_out*"
+ 
++lint_off -rule UNOPTFLAT -file "*/rtl/prim_arbiter_ppc.sv" -match "*winner*"
++
+ // Waive unused clk and reset signals: they're just used for
+ // assertions (which Verilator doesn't see)
+ lint_off -rule UNUSED -file "*/rtl/prim_arbiter_fixed.sv" -match "*clk_i*"


### PR DESCRIPTION
These lint waivers are required in the Sonata FPGA project when the CHERIoT Ibex core is connected directly through the TL-UL xbar to tlul_sram_adapter modules. They prevent spurious reports of circular combinational logic (UNOPTFLAT); in this case Verilator is warning of the impact of additional delta cycles upon simulation, not combinational loops in the logic.